### PR TITLE
Getting joker_native to compile on Mac Lion

### DIFF
--- a/ext/joker_native/Joker.c
+++ b/ext/joker_native/Joker.c
@@ -1,4 +1,8 @@
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include "Joker.h"
 #include "Wildcard.h"
 #include "compile.h"

--- a/ext/joker_native/Wildcard.c
+++ b/ext/joker_native/Wildcard.c
@@ -1,4 +1,8 @@
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <stddef.h>
 #include <Wildcard.h>
 

--- a/ext/joker_native/compile.c
+++ b/ext/joker_native/compile.c
@@ -1,4 +1,8 @@
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>

--- a/ext/joker_native/match.c
+++ b/ext/joker_native/match.c
@@ -1,4 +1,8 @@
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
 #include <malloc.h>
+#endif
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>


### PR DESCRIPTION
In the newer versions of Mac OS, <malloc.h> is included in <stdlib.h>, which causes make to fail when trying to install joker_native. 

This commit fixes this!
